### PR TITLE
fix: bad url

### DIFF
--- a/Casks/font-cheltenham.rb
+++ b/Casks/font-cheltenham.rb
@@ -2,12 +2,12 @@ cask "font-chomsky" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/martimlobao/nyt-fonts.git",
-      verified:  "github.com/martimlobao/nyt-fonts",
+  url "https://github.com/martimlobao/homebrew-nyt-fonts.git",
+      verified:  "github.com/martimlobao/homebrew-nyt-fonts",
       branch:    "main",
       only_path: "fonts/ofl/cheltenham"
   name "Cheltenham"
-  homepage "https://github.com/martimlobao/nyt-fonts"
+  homepage "https://github.com/martimlobao/homebrew-nyt-fonts"
 
   font "cheltenham-cond-normal-300.ttf"
   font "cheltenham-cond-normal-500.ttf"

--- a/Casks/font-franklin.rb
+++ b/Casks/font-franklin.rb
@@ -2,12 +2,12 @@ cask "font-franklin" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/martimlobao/nyt-fonts.git",
-      verified:  "github.com/martimlobao/nyt-fonts",
+  url "https://github.com/martimlobao/homebrew-nyt-fonts.git",
+      verified:  "github.com/martimlobao/homebrew-nyt-fonts",
       branch:    "main",
       only_path: "fonts/ofl/franklin"
   name "Franklin"
-  homepage "https://github.com/martimlobao/nyt-fonts"
+  homepage "https://github.com/martimlobao/homebrew-nyt-fonts"
 
   font "franklin-cword-normal-500.ttf"
   font "franklin-italic-300.ttf"

--- a/Casks/font-imperial.rb
+++ b/Casks/font-imperial.rb
@@ -2,12 +2,12 @@ cask "font-imperial" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/martimlobao/nyt-fonts.git",
-      verified:  "github.com/martimlobao/nyt-fonts",
+  url "https://github.com/martimlobao/homebrew-nyt-fonts.git",
+      verified:  "github.com/martimlobao/homebrew-nyt-fonts",
       branch:    "main",
       only_path: "fonts/ofl/imperial"
   name "Imperial"
-  homepage "https://github.com/martimlobao/nyt-fonts"
+  homepage "https://github.com/martimlobao/homebrew-nyt-fonts"
 
   font "imperial-italic-500.ttf"
   font "imperial-italic-600.ttf"

--- a/Casks/font-karnak.rb
+++ b/Casks/font-karnak.rb
@@ -2,12 +2,12 @@ cask "font-karnak" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/martimlobao/nyt-fonts.git",
-      verified:  "github.com/martimlobao/nyt-fonts",
+  url "https://github.com/martimlobao/homebrew-nyt-fonts.git",
+      verified:  "github.com/martimlobao/homebrew-nyt-fonts",
       branch:    "main",
       only_path: "fonts/ofl/karnak"
   name "Karnak"
-  homepage "https://github.com/martimlobao/nyt-fonts"
+  homepage "https://github.com/martimlobao/homebrew-nyt-fonts"
 
   font "karnak-normal-400.ttf"
   font "karnak-small-normal-400.ttf"

--- a/Casks/font-mag.rb
+++ b/Casks/font-mag.rb
@@ -2,12 +2,12 @@ cask "font-mag" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/martimlobao/nyt-fonts.git",
-      verified:  "github.com/martimlobao/nyt-fonts",
+  url "https://github.com/martimlobao/homebrew-nyt-fonts.git",
+      verified:  "github.com/martimlobao/homebrew-nyt-fonts",
       branch:    "main",
       only_path: "fonts/ofl/mag"
   name "Mag"
-  homepage "https://github.com/martimlobao/nyt-fonts"
+  homepage "https://github.com/martimlobao/homebrew-nyt-fonts"
 
   font "magsans-normal-500.ttf"
   font "magsans-normal-700.ttf"

--- a/Casks/font-stymie.rb
+++ b/Casks/font-stymie.rb
@@ -2,12 +2,12 @@ cask "font-stymie" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/martimlobao/nyt-fonts.git",
-      verified:  "github.com/martimlobao/nyt-fonts",
+  url "https://github.com/martimlobao/homebrew-nyt-fonts.git",
+      verified:  "github.com/martimlobao/homebrew-nyt-fonts",
       branch:    "main",
       only_path: "fonts/ofl/stymie"
   name "Stymie"
-  homepage "https://github.com/martimlobao/nyt-fonts"
+  homepage "https://github.com/martimlobao/homebrew-nyt-fonts"
 
   font "stymie-italic-300.ttf"
   font "stymie-italic-500.ttf"


### PR DESCRIPTION
- fix bad repo url in cask files

## Summary by Sourcery

Fix broken repository and homepage URLs for NYT font casks by updating references to the new homebrew-nyt-fonts repository.

Bug Fixes:
- Update cask URLs and verification entries to point to the homebrew-nyt-fonts repository
- Correct homepage links to use the homebrew-nyt-fonts repository